### PR TITLE
Fix tailwind gradient generation

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,6 +1,4 @@
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
+@import "tailwindcss";
 
 @layer base {
   :root {

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,12 +30,13 @@
         "tailwindcss-animate": "^1.0.7"
       },
       "devDependencies": {
-        "@tailwindcss/postcss": "^4.1.1",
+        "@tailwindcss/postcss": "^4.1.11",
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
         "eslint": "9.31.0",
         "eslint-config-next": "15.4.2",
+        "postcss": "^8.5.6",
         "tailwindcss": "^4.0.0",
         "typescript": "^5"
       },

--- a/package.json
+++ b/package.json
@@ -31,12 +31,13 @@
     "tailwindcss-animate": "^1.0.7"
   },
   "devDependencies": {
-    "@tailwindcss/postcss": "^4.1.1",
+    "@tailwindcss/postcss": "^4.1.11",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "eslint": "9.31.0",
     "eslint-config-next": "15.4.2",
+    "postcss": "^8.5.6",
     "tailwindcss": "^4.0.0",
     "typescript": "^5"
   },

--- a/postcss.config.mjs
+++ b/postcss.config.mjs
@@ -1,0 +1,7 @@
+const config = {
+  plugins: {
+    "@tailwindcss/postcss": {},
+  },
+};
+
+export default config;


### PR DESCRIPTION
Update Tailwind CSS configuration to v4 to correctly generate utility classes.

Tailwind CSS v4 introduced significant changes to its configuration, requiring `@import "tailwindcss"` and a `postcss.config.mjs` file to ensure utility classes are correctly generated and included in the final stylesheet.

---

**Open Background Agent:** 

[Web](https://www.cursor.com/agents?id=bc-e6317869-2f81-442c-b3ec-22f4d71917ee) · [Cursor](https://cursor.com/background-agent?bcId=bc-e6317869-2f81-442c-b3ec-22f4d71917ee)

Refer to [Background Agent docs](https://docs.cursor.com/background-agents)